### PR TITLE
Attribute setting during initialization

### DIFF
--- a/pymodeler/parameter.py
+++ b/pymodeler/parameter.py
@@ -123,7 +123,7 @@ class Property(object):
         The invokes hooks for type-checking and bounds-checking that
         may be implemented by sub-classes.        
         """
-        if kwargs.has_key('value'):
+        if 'value' in kwargs:
             self.set_value(kwargs.pop('value',None))
 
     def set_value(self, value):
@@ -423,13 +423,13 @@ class Parameter(Property):
         may be implemented by sub-classes.   
         """
         # Probably want to reset bounds if set fails
-        if kwargs.has_key('bounds'):
+        if 'bounds' in kwargs:
             self.set_bounds(kwargs.pop('bounds'))
-        if kwargs.has_key('free'):
+        if 'free' in kwargs:
             self.set_free(kwargs.pop('free'))
-        if kwargs.has_key('errors'):
+        if 'errors' in kwargs:
             self.set_errors(kwargs.pop('errors'))
-        if kwargs.has_key('value'):
+        if 'value' in kwargs:
             self.set_value(kwargs.pop('value'))
 
     def todict(self):

--- a/pymodeler/parameter.py
+++ b/pymodeler/parameter.py
@@ -77,9 +77,19 @@ class Property(object):
     def _load(self, **kwargs):
         """ Load kwargs key,value pairs into __dict__
         """
-        kw = dict([(d[0],d[1]) for d in self.defaults])
-        kw.update(kwargs)
-        self.__dict__.update(kw)
+        defaults = dict([(d[0],d[1]) for d in self.defaults])
+        # Require kwargs to be in defaults
+        for k in kwargs:
+            if k not in defaults:
+                msg = "Unrecognized attribute of %s: %s"%(self.__class__.__name__,k)
+                raise AttributeError(msg)
+        defaults.update(kwargs)
+
+        # This doesn't overwrite the properties
+        self.__dict__.update(defaults)
+         
+        # This sets the underlying property values (i.e., __value__)
+        self.set(**defaults)
 
     @property
     def value(self):
@@ -186,7 +196,9 @@ class Derived(Property):
     
     """        
 
-    defaults = Property.defaults + [('loader',    None,     'Function to load datum'       )]
+    defaults = Property.defaults + [
+        ('loader',   lambda: None,     'Function to load datum'       )
+    ]
     
     def __init__(self, **kwargs):
         """
@@ -226,6 +238,14 @@ class Parameter(Property):
     __bounds__ = None
     __free__ = False
     __errors__ = None
+
+    # Better to keep the structure consistent with Property
+    defaults = Property.defaults + [
+        ('bounds',  __bounds__,     'Allowed bounds for value'       ),
+        ('errors',  __errors__,     'Errors on this parameter'       ),
+        ('free',      __free__,     'Is this propery allowed to vary'),
+    ]
+ 
 
     def __init__(self, **kwargs):
         super(Parameter,self).__init__(**kwargs)
@@ -405,12 +425,12 @@ class Parameter(Property):
         # Probably want to reset bounds if set fails
         if kwargs.has_key('bounds'):
             self.set_bounds(kwargs.pop('bounds'))
-        if kwargs.has_key('value'):
-            self.set_value(kwargs.pop('value'))
         if kwargs.has_key('free'):
             self.set_free(kwargs.pop('free'))
         if kwargs.has_key('errors'):
             self.set_errors(kwargs.pop('errors'))
+        if kwargs.has_key('value'):
+            self.set_value(kwargs.pop('value'))
 
     def todict(self):
         """ Convert to a '~collections.OrderedDict' object.

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""
+Test the parameters
+"""
+
+from pymodeler import Parameter, Param, Property, Derived
+from collections import OrderedDict as odict
+
+def test_property():
+    int_prop = Property(default=10,dtype=int,
+                        help="I'm an int property")
+    int_prop.set_value(3)
+
+    # Shouldn't be able to set to a different type
+    try: int_prop.set_value(3.2)
+    except TypeError as e: pass
+    else: raise Exception()
+        
+    float_prop = Property(value=1.3e6,
+                          help="I'm a float parameter")
+    float_prop.set(value=0)
+    float_prop.clear_value()
+    assert float_prop.value is None
+
+    str_prop = Property(value='hello',default='world',
+                        help="I'm a str property")
+
+    assert str_prop.value == 'hello'
+    assert str_prop.innertype() is str
+
+def test_derived():
+    prop = Property(value='hello',help="Base propert")
+    loader = lambda: 'world'
+
+    # This property has nothing set
+    deriv = Derived(loader=loader)
+    assert deriv.value == loader()
+
+    # These properties are initialized
+    deriv = Derived(value='value',loader=loader)
+    assert deriv.value != loader()
+
+    deriv = Derived(default='default',loader=loader)
+    assert deriv.value != loader()
+
+    # Allow a derived property without a loader?
+    deriv = Derived()
+    assert deriv.value is None
+
+def test_parameter():
+    # Simple parameter
+    param = Parameter(value=10)
+    assert param.value == 10
+
+    # No dtype set, so this should be ok
+    param.set_value(100.)
+    assert param.value == 100.
+
+    # We currently allow any type
+    param.set_value(1.0)
+
+    # We currently allow any type (this should probably fail)
+    param.set_value('hello')
+
+    param = Parameter(value=1,bounds=[1,10],errors=[0.5,0.5],dtype=int)
+
+    print(param)
+    print(repr(param))
+
+    # We currently allow any type (this should probably fail)
+    #param.set_value('hello')
+
+
+if __name__ == "__main__":
+    test_property()
+    test_derived()
+    test_parameter()


### PR DESCRIPTION
Some changes to how `Property` and it's subclasses are initialized:
- `Property.__init__` was not calling `set_value` so `__value__` was not being set properly.
- Any values could be passed to `__init__` and filled into `__dict__` (now only allow properties in `defaults` list) 
- The default for `Derived.loader` was not a function and was crashing if not explicitly initialized.
- Added `defaults` to `Paramater` to be consistent with base class
- Added test for parameters module
- Removed `has_key` for Python3 compatibility (http://stackoverflow.com/a/1323426/4075339)
