### PR TITLE
Add __bool__ to Parameter

### DIFF
--- a/pymodeler/parameter.py
+++ b/pymodeler/parameter.py
@@ -495,7 +495,7 @@ class Parameter(Property):
         return self.__value__ != 0
 
     def __bool__(self):
-        return self.__nonzero__()
+        return self.__value__.__bool__()
 
     def __int__(self):
         return self.__value__.__int__()

--- a/pymodeler/parameter.py
+++ b/pymodeler/parameter.py
@@ -494,6 +494,9 @@ class Parameter(Property):
     def __nonzero__(self):
         return self.__value__ != 0
 
+    def __bool__(self):
+        return self.__nonzero__()
+
     def __int__(self):
         return self.__value__.__int__()
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -34,9 +34,6 @@ def test_property():
     except TypeError: pass
     else: raise TypeError
 
-    # Check that yaml works
-    dict_prop.dump()
-
     # This should be ok
     Property(value={'x':3},default=['y',2])
 
@@ -94,6 +91,9 @@ def test_parameter():
 
     print(param)
     print(repr(param))
+
+    # Check that yaml works
+    print(param.dump())
 
     # Boolean parameter
     param = Parameter(value=False,dtype=bool)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -34,7 +34,8 @@ def test_property():
     except TypeError: pass
     else: raise TypeError
 
-    print(yaml.dump(dict_prop))
+    # Check that yaml works
+    dict_prop.dump()
 
     # This should be ok
     Property(value={'x':3},default=['y',2])

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -5,6 +5,7 @@ Test the parameters
 
 from pymodeler import Parameter, Param, Property, Derived
 from collections import OrderedDict as odict
+import yaml
 
 def test_property():
     int_prop = Property(default=10,dtype=int,help="I'm an `int` property")
@@ -14,7 +15,7 @@ def test_property():
     try: int_prop.set_value(3.2)
     except TypeError: pass
     else: raise TypeError
-        
+
     float_prop = Property(value=1.3e6, help="I'm a float parameter")
     float_prop.set(value=0)
     float_prop.clear_value()
@@ -33,6 +34,8 @@ def test_property():
     except TypeError: pass
     else: raise TypeError
 
+    print(yaml.dump(dict_prop))
+
     # This should be ok
     Property(value={'x':3},default=['y',2])
 
@@ -40,6 +43,7 @@ def test_property():
     try: Property(value={'x':3},default=['y',2], dtype=dict)
     except TypeError: pass
     else: raise TypeError
+
 
 def test_derived():
     prop = Property(value='hello',help="Base property")
@@ -89,6 +93,16 @@ def test_parameter():
 
     print(param)
     print(repr(param))
+
+    # Boolean parameter
+    param = Parameter(value=False,dtype=bool)
+    if param: raise TypeError
+    param.set_value(True)
+
+    ## For right now we can only set with bools
+    try: param.set_value(1)
+    except TypeError: pass
+    else: raise AssertionError("Only boolean types should be allowed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is backporting python3 `__bool__` evaluation for `Parameter` (something that I learned the hard way elsewhere). I'm not sure how we want `__bool__` to evaluate for other `Property` subclasses.

I also wasn't sure that the `yaml` mapper and resolver were clever enough to deal with the iterator returned by python3 `dict.items`, but it looks like they are.